### PR TITLE
Remove .gamma_prefs.json from git tracking and add to .gitignore

### DIFF
--- a/.gamma_prefs.json
+++ b/.gamma_prefs.json
@@ -1,1 +1,0 @@
-{"project": "test", "flow": "testing_test", "mode": "headless"}

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ $RECYCLE.BIN/
 # Project specific
 config/local_*
 *.log
+.gamma_prefs.json


### PR DESCRIPTION
- .gamma_prefs.json contains user-specific preferences and should not be tracked
- Add .gamma_prefs.json to .gitignore to prevent future tracking
- This file stores user's last selected project, flow, and mode preferences